### PR TITLE
Issue#5 and Issue#3

### DIFF
--- a/hilgendorf_moveit_config/config/controllers.yaml
+++ b/hilgendorf_moveit_config/config/controllers.yaml
@@ -1,5 +1,5 @@
 controller_list:
-  - name: ""
+  - name: "left"
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
     joints:
@@ -9,6 +9,10 @@ controller_list:
       - left_wrist_1_joint
       - left_wrist_2_joint
       - left_wrist_3_joint
+  - name: "right"
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    joints:
       - right_shoulder_pan_joint
       - right_shoulder_lift_joint
       - right_elbow_joint

--- a/hilgendorf_support/launch/driver_hilgendorf.launch
+++ b/hilgendorf_support/launch/driver_hilgendorf.launch
@@ -9,7 +9,7 @@
   <arg name="min_payload"/>
   <arg name="max_payload"/>
   <arg name="prefix" default="" />
-  
+
   <!-- The max_velocity parameter is only used for debugging in the ur_driver. It's not related to actual velocity limits -->
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
   
@@ -24,7 +24,10 @@
     <param name="max_payload" type="double" value="$(arg max_payload)"/>
     <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
     <param name="prefix" type="str" value="$(arg prefix)" />
+    <!-- Publish joint topics on different names -->
     <remap from="joint_states" to="$(arg prefix)joint_states" />
+    <!-- Read robot description from global parameter -->
+    <remap from="robot_description" to="/robot_description"/>
   </node>
 
 </launch>

--- a/hilgendorf_support/launch/robot_interface_streaming_hilgendorf.launch
+++ b/hilgendorf_support/launch/robot_interface_streaming_hilgendorf.launch
@@ -15,15 +15,16 @@
   <include file="$(find hilgendorf_support)/launch/load_hilgendorf.launch" />
   
   <!-- launch drivers for right arm -->
-  <!-- <include file="$(find hilgendorf_support)/launch/driver_hilgendorf.launch">
+  <include file="$(find hilgendorf_support)/launch/driver_hilgendorf.launch" ns="right">
     <arg name="robot_ip" value="$(arg right_robot_ip)"/>
     <arg name="reverse_port" value="$(arg right_reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>
     <arg name="prefix" value="right_"/>
-  </include> -->
+  </include>
 
-  <include file="$(find hilgendorf_support)/launch/driver_hilgendorf.launch">
+  <!-- launch drivers for left arm -->
+  <include file="$(find hilgendorf_support)/launch/driver_hilgendorf.launch" ns="left">
     <arg name="robot_ip" value="$(arg left_robot_ip)"/>
     <arg name="reverse_port" value="$(arg left_reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
@@ -36,7 +37,7 @@
   <!-- TODO: Add launch files for the Robotiq grippers (if any) -->
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" >
-    <rosparam param="source_list">["left_joint_states", "right_joint_states"]</rosparam> 
+    <rosparam param="source_list">["/left/left_joint_states", "/right/right_joint_states"]</rosparam> 
   </node>
   
 </launch>

--- a/hilgendorf_support/launch/robot_state_visualize_hilgendorf.launch
+++ b/hilgendorf_support/launch/robot_state_visualize_hilgendorf.launch
@@ -13,7 +13,7 @@
   <include file="$(find hilgendorf_support)/launch/load_hilgendorf.launch" />
   
   <!-- launch drivers for right arm -->
-  <include file="$(find hilgendorf_support)/launch/driver_hilgendorf.launch">
+  <include file="$(find hilgendorf_support)/launch/driver_hilgendorf.launch" ns="right">
     <arg name="robot_ip" value="$(arg right_robot_ip)"/>
     <arg name="reverse_port" value="$(arg right_reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
@@ -21,7 +21,7 @@
     <arg name="prefix" value="right_"/>
   </include>
 
-  <include file="$(find hilgendorf_support)/launch/driver_hilgendorf.launch">
+  <include file="$(find hilgendorf_support)/launch/driver_hilgendorf.launch" ns="left">
     <arg name="robot_ip" value="$(arg left_robot_ip)"/>
     <arg name="reverse_port" value="$(arg left_reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
@@ -33,7 +33,7 @@
 
   <!-- If robotiq position data is not being published, ignore them-->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" >
-	  <rosparam param="source_list">["left_joint_states", "right_joint_states"]</rosparam> 
+	  <rosparam param="source_list">["/left/left_joint_states", "/right/right_joint_states"]</rosparam> 
   </node>
 
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />

--- a/hilgendorf_support/package.xml
+++ b/hilgendorf_support/package.xml
@@ -23,5 +23,6 @@
   <run_depend>ur_description</run_depend>
   <run_depend>ur_driver</run_depend>
   <run_depend>xacro</run_depend>
+  <run_depend>robotiq_c2_model_visualization</run_depend>
 
 </package>

--- a/hilgendorf_support/urdf/hilgendorf_macro.xacro
+++ b/hilgendorf_support/urdf/hilgendorf_macro.xacro
@@ -9,7 +9,7 @@
    <!-- ur5 -->
   <xacro:include filename="$(find ur_description)/urdf/ur5.urdf.xacro" />
   <!-- Robotiq c-model grippers -->
-  <xacro:include filename="$(find robotiq_c_model_visualization)/urdf/robotiq_c_model_macro.xacro" />
+  <xacro:include filename="$(find robotiq_c2_model_visualization)/urdf/robotiq_c2_model_macro.xacro" />
 
   <!-- Physical dimensions -->
   <property name="ur5_mount_angle_offset" value="-0.7853981633974483" />
@@ -25,8 +25,8 @@
     <xacro:ur5_robot prefix="${prefix}left_" joint_limited="true" />
     
     <!-- Grippers -->
-    <xacro:robotiq_c_model prefix="${prefix}right_" />
-    <xacro:robotiq_c_model prefix="${prefix}left_" />
+    <xacro:robotiq_c2_model prefix="${prefix}right_" />
+    <xacro:robotiq_c2_model prefix="${prefix}left_" />
 
     <!-- Connect arms to base -->
     <joint name="${prefix}right_shoulder_to_right_arm" type="fixed">


### PR DESCRIPTION
This commit adds appropriate depends arguments for the Robotiq visualization package now in the main Robotiq repo. 

Furthermore, it changes the moveit_config package to identify two separate controllers: one for each arm. I then namespaced the drivers in the support launch files and changed the topic remapping. I have not had a chance to extensively test, but I wanted to get this out asap.
